### PR TITLE
Put chat name and type in socket.emit message

### DIFF
--- a/server/sio.js
+++ b/server/sio.js
@@ -126,10 +126,20 @@ module.exports = function(imports) {
             for (let userId of userIds) {
                 for (let sock of online_clients[userId.toString()].sockets) {
                     if (sock !== socket.id) {
-                        io.to(sock).emit("message", {
-                            chatId: chatId,
-                            message: message,
-                        });
+                        if (chat.isTwoPeople) {
+                            io.to(sock).emit("message", {
+                                chatId: chatId,
+                                message: message,
+                                type: "pair",
+                            });
+                        } else {
+                            io.to(sock).emit("message", {
+                                chatId: chatId,
+                                message: message,
+                                type: "group",
+                                name: chat.name,
+                            });
+                        }
                     }
                 }
             }


### PR DESCRIPTION
For chat notification for group chat messages, it should say the name of the chat, so socket.emit("message") needs to send chat type and chat name.