### PR TITLE
Remove user from team

### DIFF
--- a/server/announcements.js
+++ b/server/announcements.js
@@ -63,7 +63,6 @@ module.exports = function(imports) {
                 subject: "New Announcement By " + req.user.firstname + " " + req.user.lastname,
                 html: announcement.content,
             });
-            console.log(info)
         }
 
     }));

--- a/server/chat.js
+++ b/server/chat.js
@@ -221,11 +221,11 @@ module.exports = function(imports) {
         let chat = yield Chat.findOne({
             _id: req.params.chatId,
         });
-        if(isUserInAudience(req.user, chat.audience)
+        if (isUserInAudience(req.user, chat.audience)
             && (chat.isTwoPeople  
             || util.positions.isUserAdmin(req.user) 
             || req.user._id.toString() === chat.creator.toString())
-        ){
+        ) {
             yield chat.remove(); 
             res.end();
         } else {

--- a/server/initImports.js
+++ b/server/initImports.js
@@ -53,6 +53,7 @@ module.exports = function(imports) {
 
     // TODO: add config here
 
+    module.exports.imports = imports;
     return imports;
 
 };

--- a/server/teams.js
+++ b/server/teams.js
@@ -154,21 +154,46 @@ module.exports = function(imports) {
 
         yield User.removeFromTeam(user);
 
-        let allModels = [
-            Announcement,
-            Chat,
-            Event,
-            Folder,
-        ];
-        for (let Model of allModels) {
-            yield Model.update({
+        yield Promise.all([
+            Announcement.update({
                 "audience.users": user._id,
             }, {
                 $pull: {
                     "audience.users": user._id,
                 }
-            });
-        }
+            }, {
+                multi: true,
+            }),
+            Event.update({
+                "audience.users": user._id,
+            }, {
+                $pull: {
+                    "audience.users": user._id,
+                }
+            }, {
+                multi: true,
+            }),
+            Chat.update({
+                "audience.users": user._id,
+                isTwoPeople: false,
+            }, {
+                $pull: {
+                    "audience.users": user._id,
+                }
+            }, {
+                multi: true,
+            }),
+            Folder.update({
+                "audience.users": user._id,
+                defaultFolder: false,
+            }, {
+                $pull: {
+                    "audience.users": user._id,
+                }
+            }, {
+                multi: true,
+            }),
+        ]);
 
         res.end();
 

--- a/server/util/mail.js
+++ b/server/util/mail.js
@@ -24,7 +24,9 @@ module.exports = function(imports) {
             && config.mailgunPass === defaultConfig.mailgunPass
         ) {
             return new Promise(resolve => { 
-                console.log(options); 
+                if (process.env.NODE_ENV !== "test") {
+                    console.log(options);
+                }
                 resolve(); 
             });
         } else {

--- a/test/removeFromTeam.js
+++ b/test/removeFromTeam.js
@@ -71,35 +71,26 @@ describe("removing a user from a team", function() {
         let announcements = yield sessions[0]("GET", "/announcements", {
             skip: 0,
         });
-        assert.equal(announcements[0].audience.users.length, 1,
-            "a user was removed from announcement hidden group"
-        );
-        assert.equal(announcements[0].audience.users[0]._id, data.users[0]._id,
-            "the correct user was removed from announcement hidden group"
+        assert.equal(announcements[0].audience.users.map(u => u._id), data.users[0]._id,
+            "the user was removed from announcement hidden group"
         );
     }));
 
     it("should remove the user from event hidden groups", coroutine(function*() {
         let date = new Date();
         let events = yield sessions[0]("GET",
-            `/events/startYear/${date.getFullYear() - 1}/startMonth/0
-                /endYear/${date.getFullYear() + 1}/endMonth/0`);
-        assert.equal(events[0].audience.users.length, 1,
-            "a user was removed from event hidden group"
-        );
-        assert.equal(events[0].audience.users[0], data.users[0]._id,
-            "the correct user was removed from event hidden group"
+            "/events/startYear/" + (date.getFullYear() - 1) + "/startMonth/0/endYear/"
+            + (date.getFullYear() + 1) + "/endMonth/0");
+        assert.equal(events[0].audience.users, data.users[0]._id,
+            "the user was removed from event hidden group"
         );
     }));
 
     it("should remove the user from group chat hidden groups", coroutine(function*() {
         let chats = yield sessions[0]("GET", "/chats");
         let groupChat = chats.find(chat => !chat.isTwoPeople);
-        assert.equal(groupChat.audience.users.length, 1,
-            "a user was removed from group chat hidden group"
-        );
-        assert.equal(groupChat.audience.users[0]._id, data.users[0]._id,
-            "the correct user was removed from group chat hidden group"
+        assert.equal(groupChat.audience.users.map(u => u._id), data.users[0]._id,
+            "the user was removed from group chat hidden group"
         );
     }));
 
@@ -114,11 +105,8 @@ describe("removing a user from a team", function() {
     it("should remove the user from folder hidden groups", coroutine(function*() {
         let folders = yield sessions[0]("GET", "/folders");
         let folder = folders.find(folder => !folder.defaultFolder);
-        assert.equal(folder.audience.users.length, 1,
-            "a user was removed from folder hidden group"
-        );
-        assert.equal(folder.audience.users[0], data.users[0]._id,
-            "the correct user was removed from folder hidden group"
+        assert.equal(folder.audience.users, data.users[0]._id,
+            "the user was removed from folder hidden group"
         );
     }));
 

--- a/test/removeFromTeam.js
+++ b/test/removeFromTeam.js
@@ -79,10 +79,10 @@ describe("removing a user from a team", function() {
         let announcements = yield sessions[0]("GET", "/announcements", {
             skip: 0,
         });
-        assert.equal(announcements[0].audience.users.map(u => u._id), data.users[0]._id,
+        assert.deepEqual(announcements[0].audience.users.map(u => u._id), [data.users[0]._id],
             "the user was removed from announcement hidden group"
         );
-        assert.equal(announcements[1].audience.users.map(u => u._id), data.users[0]._id,
+        assert.deepEqual(announcements[1].audience.users.map(u => u._id), [data.users[0]._id],
             "the user was removed from both announcement hidden groups"
         );
     }));
@@ -92,7 +92,7 @@ describe("removing a user from a team", function() {
         let events = yield sessions[0]("GET",
             "/events/startYear/" + (date.getFullYear() - 1) + "/startMonth/0/endYear/"
             + (date.getFullYear() + 1) + "/endMonth/0");
-        assert.equal(events[0].audience.users, data.users[0]._id,
+        assert.deepEqual(events[0].audience.users, [data.users[0]._id],
             "the user was removed from event hidden group"
         );
     }));
@@ -100,7 +100,7 @@ describe("removing a user from a team", function() {
     it("should remove the user from group chat hidden groups", coroutine(function*() {
         let chats = yield sessions[0]("GET", "/chats");
         let groupChat = chats.find(chat => !chat.isTwoPeople);
-        assert.equal(groupChat.audience.users.map(u => u._id), data.users[0]._id,
+        assert.deepEqual(groupChat.audience.users.map(u => u._id), [data.users[0]._id],
             "the user was removed from group chat hidden group"
         );
     }));
@@ -116,7 +116,7 @@ describe("removing a user from a team", function() {
     it("should remove the user from folder hidden groups", coroutine(function*() {
         let folders = yield sessions[0]("GET", "/folders");
         let folder = folders.find(folder => !folder.defaultFolder);
-        assert.equal(folder.audience.users, data.users[0]._id,
+        assert.deepEqual(folder.audience.users, [data.users[0]._id],
             "the user was removed from folder hidden group"
         );
     }));

--- a/test/removeFromTeam.js
+++ b/test/removeFromTeam.js
@@ -29,7 +29,14 @@ describe("removing a user from a team", function() {
     before(coroutine(function*() {
         yield Promise.all([
             sessions[0]("POST", "/announcements", {
-                content: "stuff",
+                content: "stuff1",
+                audience: {
+                    users: [data.users[0]._id, data.users[1]._id],
+                    groups: [],
+                },
+            }),
+            sessions[0]("POST", "/announcements", {
+                content: "stuff2",
                 audience: {
                     users: [data.users[0]._id, data.users[1]._id],
                     groups: [],
@@ -74,6 +81,9 @@ describe("removing a user from a team", function() {
         });
         assert.equal(announcements[0].audience.users.map(u => u._id), data.users[0]._id,
             "the user was removed from announcement hidden group"
+        );
+        assert.equal(announcements[1].audience.users.map(u => u._id), data.users[0]._id,
+            "the user was removed from both announcement hidden groups"
         );
     }));
 

--- a/test/removeFromTeam.js
+++ b/test/removeFromTeam.js
@@ -6,6 +6,7 @@ let assert = require("chai").assert;
 let sessions = require("./util/shared").sessions;
 let data = require("./util/shared").data;
 let delay = require("./util/delay");
+let Folder = require("./util/models").Folder;
 
 describe("removing a user from a team", function() {
 
@@ -111,11 +112,13 @@ describe("removing a user from a team", function() {
     }));
 
     it("should not remove the user from Personal Files folder hidden group", coroutine(function*() {
-        let folders = yield sessions[0]("GET", "/folders");
-        let personalFolder = folders.find(folder =>
-            folder.defaultFolder && folder.name === "Personal Files");
-        assert.equal(personalFolder.audience.users.length, 1,
-            "no user was removed from Personal Files folder hidden group"
+        let folder = yield Folder.find({
+            defaultFolder: true,
+            name: "Personal Files",
+            "audience.users": [data.users[1]._id]
+        });
+        assert.notDeepEqual(folder, [],
+            "the user was not removed from Personal Files folder hidden group"
         );
     }));
 

--- a/test/util/models.js
+++ b/test/util/models.js
@@ -1,0 +1,1 @@
+module.exports = require("../../server/initImports").imports.models;


### PR DESCRIPTION
Keep a user's private chats and Personal Files folder when he or she is removed from team. Adds tests for a user's removal from event, group chat, and folder audience when user is removed from team. Solves #28 